### PR TITLE
Configure bin in composer.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This project follows [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## <a name="unreleased"></a>Unreleased
+### Added
+* Let Composer automatically install executable in `vendor/bin`
 
 ## <a name="v0.4.2"></a>v0.4.2 (2015-06-25) 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -54,5 +54,6 @@
 		"branch-alias": {
 			"dev-master": "0.5-dev"
 		}
-	}
+	},
+	"bin": ["bin/php-semver-checker-git"]
 }


### PR DESCRIPTION
* A `composer global require` will place the php-semver-checker-git executable in `~/.composer/vendor/bin`
* A `composer require` will place the executable in `vendor/bin`

This way you can use it globally by adding it to PATH or make it easier to use per project.