### PR TITLE
Reducing complexity of execute method in SuggestCommand

### DIFF
--- a/bin/php-semver-checker-git
+++ b/bin/php-semver-checker-git
@@ -8,8 +8,7 @@ foreach (array(
 	if (file_exists($path)) {
 		require($path);
         $app = new PHPSemVerCheckerGit\Console\Application();
-        $app->run(new PHPSemVerChecker\Console\InspectableArgvInput());
-        exit(0);
+        die($app->run(new PHPSemVerChecker\Console\InspectableArgvInput()));
 	}
 }
 

--- a/bin/php-semver-checker-git
+++ b/bin/php-semver-checker-git
@@ -1,18 +1,28 @@
 #!/usr/bin/env php
 <?php
 
-foreach (array(
-             __DIR__.'/../vendor/autoload.php',
-             __DIR__.'/../../../autoload.php',
-         ) as $path) {
+$autoload_paths = array(
+	__DIR__.'/../vendor/autoload.php',
+	__DIR__.'/../../../autoload.php',
+);
+
+$found = false;
+foreach ($autoload_paths as $path) {
 	if (file_exists($path)) {
-		require($path);
-        $app = new PHPSemVerCheckerGit\Console\Application();
-        die($app->run(new PHPSemVerChecker\Console\InspectableArgvInput()));
+		require $path;
+		$found = true;
+		break;
 	}
 }
 
-die(
-    'php-semver-checker-git requires to be installed through composer.'.PHP_EOL.
-    'See http://getcomposer.org/download/'.PHP_EOL
-);
+if (!$found) {
+	die(
+		'php-semver-checker-git requires to be installed through composer.'.PHP_EOL.
+		'See http://getcomposer.org/download/'.PHP_EOL
+	);
+}
+
+ini_set('xdebug.max_nesting_level', 5000);
+
+$app = new PHPSemVerCheckerGit\Console\Application();
+$app->run(new PHPSemVerChecker\Console\InspectableArgvInput());

--- a/bin/php-semver-checker-git
+++ b/bin/php-semver-checker-git
@@ -1,28 +1,19 @@
 #!/usr/bin/env php
 <?php
 
-$autoload_paths = array(
-	__DIR__.'/../vendor/autoload.php',
-	__DIR__.'/../../../autoload.php',
-);
-
-$found = false;
-foreach ($autoload_paths as $path) {
+foreach (array(
+             __DIR__.'/../vendor/autoload.php',
+             __DIR__.'/../../../autoload.php',
+         ) as $path) {
 	if (file_exists($path)) {
-		require $path;
-		$found = true;
-		break;
+		require($path);
+        $app = new PHPSemVerCheckerGit\Console\Application();
+        $app->run(new PHPSemVerChecker\Console\InspectableArgvInput());
+        exit(0);
 	}
 }
 
-if (!$found) {
-	die(
-		'php-semver-checker-git requires to be installed through composer.'.PHP_EOL.
-		'See http://getcomposer.org/download/'.PHP_EOL
-	);
-}
-
-ini_set('xdebug.max_nesting_level', 5000);
-
-$app = new PHPSemVerCheckerGit\Console\Application();
-$app->run(new PHPSemVerChecker\Console\InspectableArgvInput());
+die(
+    'php-semver-checker-git requires to be installed through composer.'.PHP_EOL.
+    'See http://getcomposer.org/download/'.PHP_EOL
+);

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,7 @@
 		"vierbergenlars/php-semver": "^3.0"
 	},
 	"require-dev": {
-		"mockery/mockery": "^1.0",
-		"phpunit/phpunit": "^4.0|^5.0"
+		"phpunit/phpunit": "^4.8.36|^5.7.27"
 	},
 	"bin": [
 		"bin/php-semver-checker-git"
@@ -48,7 +47,7 @@
 	},
 	"autoload-dev": {
 		"psr-4": {
-			"PHPSemVerCheckerGit\\Test\\": "tests/PHPSemVerCheckerGit"
+			"PHPSemVerCheckerGit\\Test\\": "test"
 		}
 	},
 	"config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd8881f82ae2817293af2d6e07233276",
+    "content-hash": "d890a9287ae2a1670bb5a86ead2b1050",
     "packages": [
         {
             "name": "hassankhan/config",
@@ -113,20 +113,20 @@
                 "source": "https://github.com/tomzx/gitter/tree/php-semver-checker",
                 "issues": "https://github.com/tomzx/gitter/issues"
             },
-            "time": "2015-06-28T00:49:30+00:00"
+            "time": "2015-06-28 00:49:30"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v3.1.4",
+            "version": "v3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "e57b3a09784f846411aa7ed664eedb73e3399078"
+                "reference": "bb87e28e7d7b8d9a7fda231d37457c9210faf6ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/e57b3a09784f846411aa7ed664eedb73e3399078",
-                "reference": "e57b3a09784f846411aa7ed664eedb73e3399078",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/bb87e28e7d7b8d9a7fda231d37457c9210faf6ce",
+                "reference": "bb87e28e7d7b8d9a7fda231d37457c9210faf6ce",
                 "shasum": ""
             },
             "require": {
@@ -164,7 +164,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2018-01-25T21:31:33+00:00"
+            "time": "2018-02-28T20:30:58+00:00"
         },
         {
             "name": "psr/log",
@@ -215,16 +215,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.4",
+            "version": "v3.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "26b6f419edda16c19775211987651cb27baea7f1"
+                "reference": "067339e9b8ec30d5f19f5950208893ff026b94f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/26b6f419edda16c19775211987651cb27baea7f1",
-                "reference": "26b6f419edda16c19775211987651cb27baea7f1",
+                "url": "https://api.github.com/repos/symfony/console/zipball/067339e9b8ec30d5f19f5950208893ff026b94f7",
+                "reference": "067339e9b8ec30d5f19f5950208893ff026b94f7",
                 "shasum": ""
             },
             "require": {
@@ -280,20 +280,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-29T09:03:43+00:00"
+            "time": "2018-02-26T15:46:28+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.4.4",
+            "version": "v3.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "53f6af2805daf52a43b393b93d2f24925d35c937"
+                "reference": "9b1071f86e79e1999b3d3675d2e0e7684268b9bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/53f6af2805daf52a43b393b93d2f24925d35c937",
-                "reference": "53f6af2805daf52a43b393b93d2f24925d35c937",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/9b1071f86e79e1999b3d3675d2e0e7684268b9bc",
+                "reference": "9b1071f86e79e1999b3d3675d2e0e7684268b9bc",
                 "shasum": ""
             },
             "require": {
@@ -336,7 +336,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-18T22:16:57+00:00"
+            "time": "2018-02-28T21:49:22+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -399,16 +399,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v3.4.4",
+            "version": "v3.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "09a5172057be8fc677840e591b17f385e58c7c0d"
+                "reference": "cc4aea21f619116aaf1c58016a944e4821c8e8af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/09a5172057be8fc677840e591b17f385e58c7c0d",
-                "reference": "09a5172057be8fc677840e591b17f385e58c7c0d",
+                "url": "https://api.github.com/repos/symfony/process/zipball/cc4aea21f619116aaf1c58016a944e4821c8e8af",
+                "reference": "cc4aea21f619116aaf1c58016a944e4821c8e8af",
                 "shasum": ""
             },
             "require": {
@@ -444,20 +444,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-29T09:03:43+00:00"
+            "time": "2018-02-12T17:55:00+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.4",
+            "version": "v3.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "eab73b6c21d27ae4cd037c417618dfd4befb0bfe"
+                "reference": "6af42631dcf89e9c616242c900d6c52bd53bd1bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/eab73b6c21d27ae4cd037c417618dfd4befb0bfe",
-                "reference": "eab73b6c21d27ae4cd037c417618dfd4befb0bfe",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/6af42631dcf89e9c616242c900d6c52bd53bd1bb",
+                "reference": "6af42631dcf89e9c616242c900d6c52bd53bd1bb",
                 "shasum": ""
             },
             "require": {
@@ -502,7 +502,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-21T19:05:02+00:00"
+            "time": "2018-02-16T09:50:28+00:00"
         },
         {
             "name": "tomzx/finder",
@@ -555,16 +555,16 @@
         },
         {
             "name": "tomzx/php-semver-checker",
-            "version": "v0.12.0",
+            "version": "v0.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tomzx/php-semver-checker.git",
-                "reference": "9930230655d48c5e21afe3c7c2396115a49ae5ae"
+                "reference": "9e86860dfdea8ef4a69c6834665521d2ae7899e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tomzx/php-semver-checker/zipball/9930230655d48c5e21afe3c7c2396115a49ae5ae",
-                "reference": "9930230655d48c5e21afe3c7c2396115a49ae5ae",
+                "url": "https://api.github.com/repos/tomzx/php-semver-checker/zipball/9e86860dfdea8ef4a69c6834665521d2ae7899e8",
+                "reference": "9e86860dfdea8ef4a69c6834665521d2ae7899e8",
                 "shasum": ""
             },
             "require": {
@@ -585,7 +585,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.12-dev"
+                    "dev-master": "0.13-dev"
                 }
             },
             "autoload": {
@@ -611,7 +611,7 @@
                 "semantic versioning",
                 "semver"
             ],
-            "time": "2018-02-08T21:36:08+00:00"
+            "time": "2018-02-08T22:27:57+00:00"
         },
         {
             "name": "vierbergenlars/php-semver",
@@ -720,119 +720,6 @@
                 "instantiate"
             ],
             "time": "2015-06-14T21:17:01+00:00"
-        },
-        {
-            "name": "hamcrest/hamcrest-php",
-            "version": "v2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/hamcrest/hamcrest-php.git",
-                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/776503d3a8e85d4f9a1148614f95b7a608b046ad",
-                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3|^7.0"
-            },
-            "replace": {
-                "cordoval/hamcrest-php": "*",
-                "davedevelopment/hamcrest-php": "*",
-                "kodova/hamcrest-php": "*"
-            },
-            "require-dev": {
-                "phpunit/php-file-iterator": "1.3.3",
-                "phpunit/phpunit": "~4.0",
-                "satooshi/php-coveralls": "^1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "hamcrest"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD"
-            ],
-            "description": "This is the PHP port of Hamcrest Matchers",
-            "keywords": [
-                "test"
-            ],
-            "time": "2016-01-20T08:20:44+00:00"
-        },
-        {
-            "name": "mockery/mockery",
-            "version": "1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/mockery/mockery.git",
-                "reference": "1bac8c362b12f522fdd1f1fa3556284c91affa38"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/1bac8c362b12f522fdd1f1fa3556284c91affa38",
-                "reference": "1bac8c362b12f522fdd1f1fa3556284c91affa38",
-                "shasum": ""
-            },
-            "require": {
-                "hamcrest/hamcrest-php": "~2.0",
-                "lib-pcre": ">=7.0",
-                "php": ">=5.6.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~5.7|~6.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Mockery": "library/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Pádraic Brady",
-                    "email": "padraic.brady@gmail.com",
-                    "homepage": "http://blog.astrumfutura.com"
-                },
-                {
-                    "name": "Dave Marshall",
-                    "email": "dave.marshall@atstsolutions.co.uk",
-                    "homepage": "http://davedevelopment.co.uk"
-                }
-            ],
-            "description": "Mockery is a simple yet flexible PHP mock object framework for use in unit testing with PHPUnit, PHPSpec or any other testing framework. Its core goal is to offer a test double framework with a succinct API capable of clearly defining all possible object operations and interactions using a human readable Domain Specific Language (DSL). Designed as a drop in alternative to PHPUnit's phpunit-mock-objects library, Mockery is easy to integrate with PHPUnit and can operate alongside phpunit-mock-objects without the World ending.",
-            "homepage": "http://github.com/mockery/mockery",
-            "keywords": [
-                "BDD",
-                "TDD",
-                "library",
-                "mock",
-                "mock objects",
-                "mockery",
-                "stub",
-                "test",
-                "test double",
-                "testing"
-            ],
-            "time": "2017-10-06T16:20:43+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1027,16 +914,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.3",
+            "version": "1.7.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
-                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401",
                 "shasum": ""
             },
             "require": {
@@ -1048,7 +935,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
             },
             "type": "library",
             "extra": {
@@ -1086,7 +973,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-11-24T13:59:53+00:00"
+            "time": "2018-02-19T10:16:54+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <phpunit bootstrap="vendor/autoload.php">
 	<testsuite name="Tests">
-		<directory>./tests</directory>
+		<directory>./test</directory>
 	</testsuite>
 
 	<filter>

--- a/src/PHPSemVerCheckerGit/Console/Command/SuggestCommand.php
+++ b/src/PHPSemVerCheckerGit/Console/Command/SuggestCommand.php
@@ -41,7 +41,7 @@ class SuggestCommand extends BaseCommand
 
     /**
      * @param string $directory
-     * @return Repository
+     * @return \Gitter\Repository
      */
 	private function getRepository($directory)
     {
@@ -49,11 +49,11 @@ class SuggestCommand extends BaseCommand
         return $client->getRepository($directory);
     }
 
-	/**
-	 * @param InputInterface   $input
-	 * @param OutputInterface $output
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @return int
-	 */
+     */
 	protected function execute(InputInterface $input, OutputInterface $output)
     {
 		$startTime = microtime(true);
@@ -127,7 +127,7 @@ class SuggestCommand extends BaseCommand
 		$output->write(
 		    array(
 		        '',
-                '[Scanned files] Before: ' . $before->getFilteredAmount() . ' (' . $before->getUnfilteredAmount() . ' unfiltered), After: ' . $after->getFilteredAmount() . ' (' . $after->getUnfilteredAmount() . '  unfiltered)',
+                '[Scanned files] Before: ' . $before->getFilteredCount() . ' (' . $before->getUnfilteredCount() . ' unfiltered), After: ' . $after->getFilteredCount() . ' (' . $after->getUnfilteredCount() . '  unfiltered)',
                 'Time: ' . round($duration, 3) . ' seconds, Memory: ' . round(memory_get_peak_usage() / 1024 / 1024, 3) . ' MB'
             ),
             true
@@ -136,7 +136,7 @@ class SuggestCommand extends BaseCommand
 	}
 
     /**
-     * @param Report $report
+     * @param \PHPSemVerChecker\Report\Report $report
      * @param SemanticVersion $tag
      * @return SemanticVersion
      */
@@ -160,7 +160,7 @@ class SuggestCommand extends BaseCommand
     }
 
     /**
-     * @param Repository $repository
+     * @param \Gitter\Repository $repository
      * @return null|string
      */
 	private function getInitialTag(Repository $repository)
@@ -173,7 +173,7 @@ class SuggestCommand extends BaseCommand
     }
 
 	/**
-	 * @param Repository $repository
+	 * @param \Gitter\Repository $repository
 	 * @return string|null
 	 */
 	protected function findLatestTag(Repository $repository)
@@ -182,7 +182,7 @@ class SuggestCommand extends BaseCommand
 	}
 
 	/**
-	 * @param Repository $repository
+	 * @param \Gitter\Repository $repository
 	 * @param string             $tag
 	 * @return string|null
 	 */
@@ -203,6 +203,10 @@ class SuggestCommand extends BaseCommand
 		return $this->getMappedVersionTag($tags, $satisfyingTag);
 	}
 
+    /**
+     * @param array $tags
+     * @return array
+     */
 	private function filterTags(array $tags)
 	{
 		$filteredTags = [];
@@ -218,7 +222,7 @@ class SuggestCommand extends BaseCommand
 	}
 
 	/**
-	 * @param string[]                                   $tags
+	 * @param string[] $tags
 	 * @param SemanticVersion|string|null $versionTag
 	 * @return string|null
 	 */

--- a/src/PHPSemVerCheckerGit/Console/Command/SuggestCommand.php
+++ b/src/PHPSemVerCheckerGit/Console/Command/SuggestCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use vierbergenlars\SemVer\expression as SemanticExpression;
 use vierbergenlars\SemVer\SemVerException as SemanticVersionException;
 use vierbergenlars\SemVer\version as SemanticVersion;
+use PHPSemVerChecker\Report\Report;
 
 class SuggestCommand extends BaseCommand
 {

--- a/src/PHPSemVerCheckerGit/Console/Command/SuggestCommand.php
+++ b/src/PHPSemVerCheckerGit/Console/Command/SuggestCommand.php
@@ -55,7 +55,7 @@ class SuggestCommand extends BaseCommand
      * @return int
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output)
-	{
+    {
 		$startTime = microtime(true);
 
 		$targetDirectory = getcwd();

--- a/src/PHPSemVerCheckerGit/Console/Command/SuggestCommand.php
+++ b/src/PHPSemVerCheckerGit/Console/Command/SuggestCommand.php
@@ -5,7 +5,9 @@ namespace PHPSemVerCheckerGit\Console\Command;
 use Gitter\Client;
 use Gitter\Repository;
 use PHPSemVerChecker\Analyzer\Analyzer;
+use PHPSemVerChecker\Console\Command\BaseCommand;
 use PHPSemVerChecker\Finder\Finder;
+use PHPSemVerChecker\Report\Report;
 use PHPSemVerChecker\Reporter\Reporter;
 use PHPSemVerChecker\SemanticVersioning\Level;
 use PHPSemVerCheckerGit\Filter\SourceFilter;
@@ -17,7 +19,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use vierbergenlars\SemVer\expression as SemanticExpression;
 use vierbergenlars\SemVer\SemVerException as SemanticVersionException;
 use vierbergenlars\SemVer\version as SemanticVersion;
-use PHPSemVerChecker\Report\Report;
 
 class SuggestCommand extends BaseCommand
 {
@@ -50,8 +51,8 @@ class SuggestCommand extends BaseCommand
     }
 
 	/**
-	 * @param \Symfony\Component\Console\Input\InputInterface   $input
-	 * @param \Symfony\Component\Console\Output\OutputInterface $output
+	 * @param InputInterface   $input
+	 * @param OutputInterface $output
      * @return int
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output)
@@ -127,7 +128,7 @@ class SuggestCommand extends BaseCommand
 		$output->write(
 		    array(
 		        '',
-                '[Scanned files] Before: ' . count($before->getFiles()) . ' (' . $before->getOriginalAmount() . ' unfiltered), After: ' . count($after->getFiles()) . ' (' . $after->getOriginalAmount() . '  unfiltered)',
+                '[Scanned files] Before: ' . $before->getFilteredAmount() . ' (' . $before->getUnfilteredAmount() . ' unfiltered), After: ' . $after->getFilteredAmount() . ' (' . $after->getUnfilteredAmount() . '  unfiltered)',
                 'Time: ' . round($duration, 3) . ' seconds, Memory: ' . round(memory_get_peak_usage() / 1024 / 1024, 3) . ' MB'
             ),
             true
@@ -173,7 +174,7 @@ class SuggestCommand extends BaseCommand
     }
 
 	/**
-	 * @param \Gitter\Repository $repository
+	 * @param Repository $repository
 	 * @return string|null
 	 */
 	protected function findLatestTag(Repository $repository)
@@ -182,7 +183,7 @@ class SuggestCommand extends BaseCommand
 	}
 
 	/**
-	 * @param \Gitter\Repository $repository
+	 * @param Repository $repository
 	 * @param string             $tag
 	 * @return string|null
 	 */
@@ -219,7 +220,7 @@ class SuggestCommand extends BaseCommand
 
 	/**
 	 * @param string[]                                   $tags
-	 * @param \vierbergenlars\SemVer\version|string|null $versionTag
+	 * @param SemanticVersion|string|null $versionTag
 	 * @return string|null
 	 */
 	private function getMappedVersionTag(array $tags, $versionTag)

--- a/src/PHPSemVerCheckerGit/Console/Command/SuggestCommand.php
+++ b/src/PHPSemVerCheckerGit/Console/Command/SuggestCommand.php
@@ -18,7 +18,6 @@ use vierbergenlars\SemVer\expression as SemanticExpression;
 use vierbergenlars\SemVer\SemVerException as SemanticVersionException;
 use vierbergenlars\SemVer\version as SemanticVersion;
 use PHPSemVerChecker\Report\Report;
-use vierbergenlars\SemVer\version;
 
 class SuggestCommand extends BaseCommand
 {
@@ -53,7 +52,7 @@ class SuggestCommand extends BaseCommand
 	/**
 	 * @param \Symfony\Component\Console\Input\InputInterface   $input
 	 * @param \Symfony\Component\Console\Output\OutputInterface $output
-     * @return void
+     * @return int
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output)
 	{
@@ -68,7 +67,7 @@ class SuggestCommand extends BaseCommand
 
 		if ($tag === null) {
 			$output->writeln('<error>No tags to suggest against</error>');
-			return;
+			return 1;
 		}
 
 		$output->writeln('<info>Testing ' . $against . ' against tag: ' . $tag . '</info>');
@@ -133,15 +132,15 @@ class SuggestCommand extends BaseCommand
             ),
             true
         );
+		return 0;
 	}
 
     /**
      * @param Report $report
-     * @param version $tag
+     * @param SemanticVersion $tag
      * @return SemanticVersion
-     * @throws \vierbergenlars\SemVer\LogicException
      */
-	private function getNextTag(Report $report, version $tag)
+	private function getNextTag(Report $report, SemanticVersion $tag)
     {
         $newTag = new SemanticVersion($tag);
         $suggestedLevel = $report->getSuggestedLevel();

--- a/src/PHPSemVerCheckerGit/Console/Command/SuggestCommand.php
+++ b/src/PHPSemVerCheckerGit/Console/Command/SuggestCommand.php
@@ -18,6 +18,7 @@ use vierbergenlars\SemVer\expression as SemanticExpression;
 use vierbergenlars\SemVer\SemVerException as SemanticVersionException;
 use vierbergenlars\SemVer\version as SemanticVersion;
 use PHPSemVerChecker\Report\Report;
+use vierbergenlars\SemVer\version;
 
 class SuggestCommand extends BaseCommand
 {

--- a/src/PHPSemVerCheckerGit/Console/Command/SuggestCommand.php
+++ b/src/PHPSemVerCheckerGit/Console/Command/SuggestCommand.php
@@ -5,7 +5,6 @@ namespace PHPSemVerCheckerGit\Console\Command;
 use Gitter\Client;
 use Gitter\Repository;
 use PHPSemVerChecker\Analyzer\Analyzer;
-use PHPSemVerChecker\Console\Command\BaseCommand;
 use PHPSemVerChecker\Finder\Finder;
 use PHPSemVerChecker\Report\Report;
 use PHPSemVerChecker\Reporter\Reporter;

--- a/src/PHPSemVerCheckerGit/ProcessedFileList.php
+++ b/src/PHPSemVerCheckerGit/ProcessedFileList.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace PHPSemVerCheckerGit;
+
+use PHPSemVerChecker\Scanner\Scanner;
+
+class ProcessedFileList
+{
+    /**
+     * @var int
+     */
+    private $originalAmount;
+    /**
+     * @var string[]
+     */
+    private $files;
+    /**
+     * @var Scanner
+     */
+    private $scanner;
+
+    /**
+     * ProcessedFileList constructor.
+     * @param int $originalAmount
+     * @param string[] $files
+     * @param Scanner $scanner
+     */
+    public function __construct($originalAmount, array &$files, Scanner &$scanner)
+    {
+        $this->originalAmount = $originalAmount;
+        $this->files = $files;
+        $this->scanner = $scanner;
+    }
+
+    /**
+     * @return Scanner
+     */
+    public function getScanner()
+    {
+        return $this->scanner;
+    }
+
+    /**
+     * @return int
+     */
+    public function getOriginalAmount()
+    {
+        return $this->originalAmount;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getFiles()
+    {
+        return $this->files;
+    }
+
+}

--- a/src/PHPSemVerCheckerGit/ProcessedFileList.php
+++ b/src/PHPSemVerCheckerGit/ProcessedFileList.php
@@ -9,12 +9,12 @@ class ProcessedFileList
     /**
      * @var int
      */
-    private $unfilteredAmount;
+    private $unfilteredCount;
 
     /**
      * @var int
      */
-    private $filteredAmount;
+    private $filteredCount;
 
     /**
      * @var string[]
@@ -27,7 +27,7 @@ class ProcessedFileList
     private $unfiltered;
 
     /**
-     * @var Scanner
+     * @var \PHPSemVerChecker\Scanner\Scanner
      */
     private $scanner;
 
@@ -35,19 +35,19 @@ class ProcessedFileList
      * ProcessedFileList constructor.
      * @param string[] $unfiltered
      * @param string[] $filtered
-     * @param Scanner $scanner
+     * @param \PHPSemVerChecker\Scanner\Scanner $scanner
      */
     public function __construct(array $unfiltered, array $filtered, Scanner &$scanner)
     {
-        $this->unfilteredAmount = count($unfiltered);
-        $this->filteredAmount = count($filtered);
+        $this->unfilteredCount = count($unfiltered);
+        $this->filteredCount = count($filtered);
         $this->filtered = $filtered;
         $this->unfiltered = $unfiltered;
         $this->scanner = $scanner;
     }
 
     /**
-     * @return Scanner
+     * @return \PHPSemVerChecker\Scanner\Scanner
      */
     public function getScanner()
     {
@@ -65,17 +65,17 @@ class ProcessedFileList
     /**
      * @return int
      */
-    public function getFilteredAmount()
+    public function getFilteredCount()
     {
-        return $this->filteredAmount;
+        return $this->filteredCount;
     }
 
     /**
      * @return int
      */
-    public function getUnfilteredAmount()
+    public function getUnfilteredCount()
     {
-        return $this->unfilteredAmount;
+        return $this->unfilteredCount;
     }
 
     /**

--- a/src/PHPSemVerCheckerGit/ProcessedFileList.php
+++ b/src/PHPSemVerCheckerGit/ProcessedFileList.php
@@ -9,11 +9,23 @@ class ProcessedFileList
     /**
      * @var int
      */
-    private $originalAmount;
+    private $unfilteredAmount;
+
+    /**
+     * @var int
+     */
+    private $filteredAmount;
+
     /**
      * @var string[]
      */
-    private $files;
+    private $filtered;
+
+    /**
+     * @var string[]
+     */
+    private $unfiltered;
+
     /**
      * @var Scanner
      */
@@ -21,14 +33,16 @@ class ProcessedFileList
 
     /**
      * ProcessedFileList constructor.
-     * @param int $originalAmount
-     * @param string[] $files
+     * @param string[] $unfiltered
+     * @param string[] $filtered
      * @param Scanner $scanner
      */
-    public function __construct($originalAmount, array &$files, Scanner &$scanner)
+    public function __construct(array $unfiltered, array $filtered, Scanner &$scanner)
     {
-        $this->originalAmount = $originalAmount;
-        $this->files = $files;
+        $this->unfilteredAmount = count($unfiltered);
+        $this->filteredAmount = count($filtered);
+        $this->filtered = $filtered;
+        $this->unfiltered = $unfiltered;
         $this->scanner = $scanner;
     }
 
@@ -41,19 +55,34 @@ class ProcessedFileList
     }
 
     /**
+     * @return string[]
+     */
+    public function getFiltered()
+    {
+        return $this->filtered;
+    }
+
+    /**
      * @return int
      */
-    public function getOriginalAmount()
+    public function getFilteredAmount()
     {
-        return $this->originalAmount;
+        return $this->filteredAmount;
+    }
+
+    /**
+     * @return int
+     */
+    public function getUnfilteredAmount()
+    {
+        return $this->unfilteredAmount;
     }
 
     /**
      * @return string[]
      */
-    public function getFiles()
+    public function getUnfiltered()
     {
-        return $this->files;
+        return $this->unfiltered;
     }
-
 }

--- a/src/PHPSemVerCheckerGit/SourceFileProcessor.php
+++ b/src/PHPSemVerCheckerGit/SourceFileProcessor.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace PHPSemVerCheckerGit;
+
+
+use PHPSemVerChecker\Finder\Finder;
+use PHPSemVerChecker\Scanner\Scanner;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\ProgressBar;
+
+class SourceFileProcessor
+{
+    /**
+     * @var Repository
+     */
+    private $repository;
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+    /**
+     * @var Finder
+     */
+    private $finder;
+    /**
+     * @var string
+     */
+    private $directory;
+    /**
+     * @var string[]
+     */
+    private $modifiedFiles;
+
+    /**
+     * SourceFileProcessor constructor.
+     * @param SourceFilter &$filter
+     * @param Repository $repository
+     * @param OutputInterface $output
+     * @param Finder $finder
+     * @param string $directory
+     * @param string[] $modifiedFiles
+     */
+    public function __construct(SourceFilter $filter, Repository $repository, OutputInterface $output, Finder $finder, $directory, array $modifiedFiles)
+    {
+        $this->repository = $repository;
+        $this->output = $output;
+        $this->finder = $finder;
+        $this->directory = $directory;
+        $this->addModifiedFiles($modifiedFiles);
+    }
+
+    /**
+     * @param string[] $modified
+     */
+    private function addModifiedFiles(array $modified) {
+        foreach($modified as $file) {
+            if(substr($file, -4) === '.php') {
+                $this->modifiedFiles[] = $file;
+            }
+        }
+    }
+
+
+    /**
+     * @param Scanner $scanner
+     * @param string $commitIdentifier
+     * @param $include
+     * @param $exclude
+     * @return array
+     */
+    public function processFileList(
+        Scanner &$scanner,
+        $commitIdentifier,
+        $include,
+        $exclude
+    ) {
+        $this->repository->checkout($commitIdentifier . ' --');
+        $source = $this->finder->findFromString($this->directory, $include, $exclude);
+        $count = count($source);
+        $source = $this->filter->filter($source, $this->modifiedFiles);
+        $this->scanFileList($scanner, $source);
+        return array($count, $source);
+    }
+
+    /**
+     * @param Scanner $scanner
+     * @param array $files
+     */
+    private function scanFileList(Scanner &$scanner, array &$files)
+    {
+        $progress = new ProgressBar($this->output, count($files));
+        foreach ($files as $file) {
+            $scanner->scan($file);
+            $progress->advance();
+        }
+        $progress->clear();
+    }
+
+}

--- a/src/PHPSemVerCheckerGit/SourceFileProcessor.php
+++ b/src/PHPSemVerCheckerGit/SourceFileProcessor.php
@@ -71,7 +71,7 @@ class SourceFileProcessor
         $scanner = new Scanner();
         $this->repository->checkout($commitIdentifier . ' --');
         $unfiltered = $this->finder->findFromString($this->directory, $include, $exclude);
-        $source = $this->filter->filter($source, $this->modifiedFiles);
+        $source = $this->filter->filter($unfiltered, $this->modifiedFiles);
         $this->scanFileList($scanner, $source);
         return new ProcessedFileList($unfiltered, $source, $scanner);
     }

--- a/src/PHPSemVerCheckerGit/SourceFileProcessor.php
+++ b/src/PHPSemVerCheckerGit/SourceFileProcessor.php
@@ -23,6 +23,10 @@ class SourceFileProcessor
      */
     private $finder;
     /**
+     * @var SourceFilter
+     */
+    private $filter;
+    /**
      * @var string
      */
     private $directory;
@@ -45,41 +49,33 @@ class SourceFileProcessor
         $this->repository = $repository;
         $this->output = $output;
         $this->finder = $finder;
+        $this->filter = $filter;
         $this->directory = $directory;
-        $this->addModifiedFiles($modifiedFiles);
-    }
-
-    /**
-     * @param string[] $modified
-     */
-    private function addModifiedFiles(array $modified) {
-        foreach($modified as $file) {
+        foreach($modifiedFiles as $file) {
             if(substr($file, -4) === '.php') {
                 $this->modifiedFiles[] = $file;
             }
         }
     }
 
-
     /**
-     * @param Scanner $scanner
      * @param string $commitIdentifier
      * @param $include
      * @param $exclude
-     * @return array
+     * @return ProcessedFileList
      */
     public function processFileList(
-        Scanner &$scanner,
         $commitIdentifier,
         $include,
         $exclude
     ) {
+        $scanner = new Scanner();
         $this->repository->checkout($commitIdentifier . ' --');
         $source = $this->finder->findFromString($this->directory, $include, $exclude);
         $count = count($source);
         $source = $this->filter->filter($source, $this->modifiedFiles);
         $this->scanFileList($scanner, $source);
-        return array($count, $source);
+        return new ProcessedFileList($count, $source, $scanner);
     }
 
     /**

--- a/src/PHPSemVerCheckerGit/SourceFileProcessor.php
+++ b/src/PHPSemVerCheckerGit/SourceFileProcessor.php
@@ -7,6 +7,8 @@ use PHPSemVerChecker\Finder\Finder;
 use PHPSemVerChecker\Scanner\Scanner;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Helper\ProgressBar;
+use PHPSemVerCheckerGit\Filter\SourceFilter;
+use Gitter\Repository;
 
 class SourceFileProcessor
 {

--- a/src/PHPSemVerCheckerGit/SourceFileProcessor.php
+++ b/src/PHPSemVerCheckerGit/SourceFileProcessor.php
@@ -2,36 +2,40 @@
 
 namespace PHPSemVerCheckerGit;
 
-
+use Gitter\Repository;
 use PHPSemVerChecker\Finder\Finder;
 use PHPSemVerChecker\Scanner\Scanner;
-use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Helper\ProgressBar;
 use PHPSemVerCheckerGit\Filter\SourceFilter;
-use Gitter\Repository;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class SourceFileProcessor
 {
     /**
-     * @var Repository
+     * @var \Gitter\Repository
      */
     private $repository;
+
     /**
-     * @var OutputInterface
+     * @var \Symfony\Component\Console\Output\OutputInterface
      */
     private $output;
+
     /**
-     * @var Finder
+     * @var \PHPSemVerChecker\Finder\Finder
      */
     private $finder;
+
     /**
-     * @var SourceFilter
+     * @var \PHPSemVerCheckerGit\Filter\SourceFilter
      */
     private $filter;
+
     /**
      * @var string
      */
     private $directory;
+
     /**
      * @var string[]
      */
@@ -39,10 +43,10 @@ class SourceFileProcessor
 
     /**
      * SourceFileProcessor constructor.
-     * @param SourceFilter &$filter
-     * @param Repository $repository
-     * @param OutputInterface $output
-     * @param Finder $finder
+     * @param PHPSemVerCheckerGit\Filter\SourceFilter $filter
+     * @param \Gitter\Repository $repository
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param \PHPSemVerChecker\Finder\Finder $finder
      * @param string $directory
      * @param string[] $modifiedFiles
      */
@@ -64,7 +68,7 @@ class SourceFileProcessor
      * @param string $commitIdentifier
      * @param $include
      * @param $exclude
-     * @return ProcessedFileList
+     * @return \PHPSemVerCheckerGit\ProcessedFileList
      */
     public function processFileList($commitIdentifier, $include, $exclude)
     {
@@ -77,7 +81,7 @@ class SourceFileProcessor
     }
 
     /**
-     * @param Scanner $scanner
+     * @param \PHPSemVerChecker\Scanner\Scanner $scanner
      * @param array $files
      */
     private function scanFileList(Scanner $scanner, array $files)

--- a/src/PHPSemVerCheckerGit/SourceFileProcessor.php
+++ b/src/PHPSemVerCheckerGit/SourceFileProcessor.php
@@ -66,25 +66,21 @@ class SourceFileProcessor
      * @param $exclude
      * @return ProcessedFileList
      */
-    public function processFileList(
-        $commitIdentifier,
-        $include,
-        $exclude
-    ) {
+    public function processFileList($commitIdentifier, $include, $exclude)
+    {
         $scanner = new Scanner();
         $this->repository->checkout($commitIdentifier . ' --');
-        $source = $this->finder->findFromString($this->directory, $include, $exclude);
-        $count = count($source);
+        $unfiltered = $this->finder->findFromString($this->directory, $include, $exclude);
         $source = $this->filter->filter($source, $this->modifiedFiles);
         $this->scanFileList($scanner, $source);
-        return new ProcessedFileList($count, $source, $scanner);
+        return new ProcessedFileList($unfiltered, $source, $scanner);
     }
 
     /**
      * @param Scanner $scanner
      * @param array $files
      */
-    private function scanFileList(Scanner &$scanner, array &$files)
+    private function scanFileList(Scanner $scanner, array $files)
     {
         $progress = new ProgressBar($this->output, count($files));
         foreach ($files as $file) {
@@ -93,5 +89,4 @@ class SourceFileProcessor
         }
         $progress->clear();
     }
-
 }

--- a/test/Console/Command/SuggestCommandTest.php
+++ b/test/Console/Command/SuggestCommandTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace PHPSemVerCheckerGit\Test;
+
+use PHPSemVerCheckerGit\Console\Command\SuggestCommand;
+use PHPUnit\Framework\TestCase;
+use PHPSemVerChecker\SemanticVersioning\Level;
+use vierbergenlars\SemVer\version;
+
+class SuggestCommandTest extends TestCase
+{
+    /**
+     * @todo properly mock
+     * @param int $major
+     * @param int $minor
+     * @param int $patch
+     * @return version
+     */
+    private function getMockedVersion($major, $minor, $patch)
+    {
+        return new version("$major.$minor.$patch", true);
+    }
+
+    /**
+     * Provides a few test cases
+     * @return array
+     */
+    public function provideGetNextTag() {
+        return array(
+            //v0.1.0
+            array(Level::NONE, $this->getMockedVersion(0,1,0), '0.1.0'),
+            array(Level::PATCH, $this->getMockedVersion(0,1,0), '0.1.1'),
+            array(Level::MINOR, $this->getMockedVersion(0,1,0), '0.2.0'),
+            array(Level::MAJOR, $this->getMockedVersion(0,1,0), '0.2.0'),
+            //v1.0.0
+            array(Level::NONE, $this->getMockedVersion(1,0,0), '1.0.0'),
+            array(Level::PATCH, $this->getMockedVersion(1,0,0), '1.0.1'),
+            array(Level::MINOR, $this->getMockedVersion(1,0,0), '1.1.0'),
+            array(Level::MAJOR, $this->getMockedVersion(1,0,0), '2.0.0'),
+            //v2.3.4
+            array(Level::NONE, $this->getMockedVersion(2,3,4), '2.3.4'),
+            array(Level::PATCH, $this->getMockedVersion(2,3,4), '2.3.5'),
+            array(Level::MINOR, $this->getMockedVersion(2,3,4), '2.4.0'),
+            array(Level::MAJOR, $this->getMockedVersion(2,3,4), '3.0.0'),
+        );
+    }
+
+    /**
+     * @param $level
+     * @param $version
+     * @param $expected
+     * @throws \ReflectionException
+     * @test
+     * @dataProvider provideGetNextTag
+     */
+    public function testGetNextTag($level, version $version, $expected) {
+        $report = $this->getMockBuilder('PHPSemVerChecker\Report\Report')->disableOriginalConstructor()->getMock();
+        $report->expects($this->once())->method('getSuggestedLevel')->willReturn($level);
+        $instance = new SuggestCommand();
+        $rc = new \ReflectionClass('PHPSemVerCheckerGit\Console\Command\SuggestCommand');
+        $method = $rc->getMethod('getNextTag');
+        $method->setAccessible(true);
+        $result = $method->invoke($instance, $report, $version);
+        $this->assertInstanceOf('vierbergenlars\SemVer\version', $result);
+        $this->assertEquals($expected, $result->getVersion());
+    }
+}

--- a/test/Console/Command/SuggestCommandTest.php
+++ b/test/Console/Command/SuggestCommandTest.php
@@ -32,6 +32,11 @@ class SuggestCommandTest extends TestCase
             array(Level::PATCH, $this->getMockedVersion(0,1,0), '0.1.1'),
             array(Level::MINOR, $this->getMockedVersion(0,1,0), '0.2.0'),
             array(Level::MAJOR, $this->getMockedVersion(0,1,0), '0.2.0'),
+            //v1.0.0RC1
+            array(Level::NONE, $this->getMockedVersion(1,0,'0-1'), '1.0.0-1'),
+            array(Level::PATCH, $this->getMockedVersion(1,0,'0-1'), '1.0.0-2'),
+            array(Level::MINOR, $this->getMockedVersion(1,0,'0-1'), '1.0.0-2'),
+            array(Level::MAJOR, $this->getMockedVersion(1,0,'0-1'), '1.0.0-2'),
             //v1.0.0
             array(Level::NONE, $this->getMockedVersion(1,0,0), '1.0.0'),
             array(Level::PATCH, $this->getMockedVersion(1,0,0), '1.0.1'),

--- a/test/Console/Command/SuggestCommandTest.php
+++ b/test/Console/Command/SuggestCommandTest.php
@@ -2,9 +2,12 @@
 
 namespace PHPSemVerCheckerGit\Test;
 
+use PHPSemVerChecker\SemanticVersioning\Level;
 use PHPSemVerCheckerGit\Console\Command\SuggestCommand;
 use PHPUnit\Framework\TestCase;
-use PHPSemVerChecker\SemanticVersioning\Level;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionMethod;
 use vierbergenlars\SemVer\version;
 
 class SuggestCommandTest extends TestCase
@@ -19,6 +22,18 @@ class SuggestCommandTest extends TestCase
     private function getMockedVersion($major, $minor, $patch)
     {
         return new version("$major.$minor.$patch", true);
+    }
+
+    /**
+     * @return ReflectionMethod
+     * @throws ReflectionException
+     */
+    private function getNextTagMethod()
+    {
+        $class = new ReflectionClass('PHPSemVerCheckerGit\Console\Command\SuggestCommand');
+        $method = $class->getMethod('getNextTag');
+        $method->setAccessible(true);
+        return $method;
     }
 
     /**
@@ -54,18 +69,16 @@ class SuggestCommandTest extends TestCase
      * @param $level
      * @param $version
      * @param $expected
-     * @throws \ReflectionException
+     * @throws ReflectionException
      * @test
      * @dataProvider provideGetNextTag
      */
-    public function testGetNextTag($level, version $version, $expected) {
+    public function testGetNextTag($level, version $version, $expected)
+    {
         $report = $this->getMockBuilder('PHPSemVerChecker\Report\Report')->disableOriginalConstructor()->getMock();
         $report->expects($this->once())->method('getSuggestedLevel')->willReturn($level);
-        $instance = new SuggestCommand();
-        $rc = new \ReflectionClass('PHPSemVerCheckerGit\Console\Command\SuggestCommand');
-        $method = $rc->getMethod('getNextTag');
-        $method->setAccessible(true);
-        $result = $method->invoke($instance, $report, $version);
+
+        $result = $this->getNextTagMethod()->invoke(new SuggestCommand(), $report, $version);
         $this->assertInstanceOf('vierbergenlars\SemVer\version', $result);
         $this->assertEquals($expected, $result->getVersion());
     }

--- a/test/Console/Command/SuggestCommandTest.php
+++ b/test/Console/Command/SuggestCommandTest.php
@@ -6,8 +6,6 @@ use PHPSemVerChecker\SemanticVersioning\Level;
 use PHPSemVerCheckerGit\Console\Command\SuggestCommand;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
-use ReflectionException;
-use ReflectionMethod;
 use vierbergenlars\SemVer\version;
 
 class SuggestCommandTest extends TestCase
@@ -17,7 +15,7 @@ class SuggestCommandTest extends TestCase
      * @param int $major
      * @param int $minor
      * @param int $patch
-     * @return version
+     * @return \vierbergenlars\SemVer\version
      */
     private function getMockedVersion($major, $minor, $patch)
     {
@@ -25,8 +23,8 @@ class SuggestCommandTest extends TestCase
     }
 
     /**
-     * @return ReflectionMethod
-     * @throws ReflectionException
+     * @return \ReflectionMethod
+     * @throws \ReflectionException
      */
     private function getNextTagMethod()
     {
@@ -67,9 +65,9 @@ class SuggestCommandTest extends TestCase
 
     /**
      * @param $level
-     * @param $version
+     * @param \vierbergenlars\SemVer\version $version
      * @param $expected
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @test
      * @dataProvider provideGetNextTag
      */


### PR DESCRIPTION
I took the liberty of ripping appart the execute method to make other goals(like testing) easier to achieve.

The following was done:
- moved duplicate code to methods
- extracted classes to wrap logically related functionality or data